### PR TITLE
CLIP-1757: Update ganesha to v4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,14 @@
 # limitations under the License.
 
 FROM centos:latest
+RUN cd /etc/yum.repos.d/
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
 
-RUN yum -y install \
-    centos-release-nfs-ganesha30 \
+RUN yum install centos-stream-repos --allowerasing -y && \
+    yum upgrade -y && \
+    yum -y install \
+    centos-release-nfs-ganesha4 \
     && yum -y install \
     nfs-ganesha \
     nfs-ganesha-vfs \


### PR DESCRIPTION
This PR bumps version of ganesha from 3 to 4. 

From time to time we see the following error when trying to scale Bitbucket:

```
2023-01-31 21:01:04,693 ERROR [spring-startup]  c.a.s.internal.home.HomeLockAcquirer Lock file /var/atlassian/application-data/shared-home/.lock cannot be obtained in home directory /var/atlassian/application-data/shared-home. Does bitbucket have write permission on that directory? Is file locking enabled for the filesystem?
```
NFS logs go as follows:

```
31/01/2023 21:01:04 : epoch 63d8bc49 : bitbucket-nfs-server-0 : nfs-ganesha-15[svc_3012] nsm_monitor :NLM :EVENT :Monitor ::ffff:10.0.0.143 SM_MON failed: RPC: Timed out
```

Having updated and tested the image with ganesha4, the issue cannot be reproduced and no lock errors are found.
